### PR TITLE
Mount repeated dynamic module individually per data-flags

### DIFF
--- a/src/generator/snippet.ts
+++ b/src/generator/snippet.ts
@@ -4,13 +4,13 @@ export const staticElmInitCode = (moduleName: string, flags: object): string => 
     `
 }
 
-export const dynamicElmInitCode = (moduleName: string, flags: string): string => {
+export const dynamicElmInitCode = (moduleName: string, flags: string, key: string): string => {
     const objName = moduleName.replace('.', '')
     return `
         window.app = window.app || {}
-        var ns = document.querySelectorAll('div[data-elm-module="${moduleName}"]')
+        var ns = document.querySelectorAll('div[data-elm-module="${moduleName}"][data-unique-key="${key}"]')
         for(var i=0;i<ns.length;i++){
-            var name = '${objName}' + (i > 0 ? ('_' + i) : '')
+            var name = '${objName}_${key}' + (i > 0 ? ('_' + i) : '')
             window.app[name] = Elm.${moduleName}.init({node:ns[i],flags:${flags}})
         }
     `


### PR DESCRIPTION
Thanks for publishing such the awesome module 👏 👏 👏 This module helps me a lot to build the kind of blog system with Elm. Then I found an unintentional behavior.

When we repeat the same dynamic Elm module with different flags. The flags for the first one are reused for others.

```diff
        , div []
            [ h2 [] [ text "dynamic components" ]
            , div [ class "inner" ]
                [ text "with Browser.element, dynamic contents can be embedded"
                , Html.dynamic
                    { moduleName = "Dynamic.Counter"
                    , flags = "{value: 100}"
                    }
                ]
            ]
+       , div []
+           [ h2 [] [ text "dynamic components (repeated)" ]
+           , div [ class "inner" ]
+               [ text "with Browser.element, dynamic contents can be embedded"
+               , Html.dynamic
+                   { moduleName = "Dynamic.Counter"
+                   , flags = "{value: 300}"
+                   }
+               ]
+           ]
```

Giving `{ value: 300 }` for the second one, but `{ value: 100 }` from the first one is used:

![image](https://user-images.githubusercontent.com/85887/79083940-049de380-7ce6-11ea-9291-c200e5a03276.png)

So, this PR tries to solve the problem by giving a unique key with basing on serialized `flags` automatically.