### PR TITLE
Fix problem that dir name is omitted from preamble.url

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -122,7 +122,7 @@ const convertAndSave = (file: string, config: Config, elmcode: string, appjs: st
     console.log(`> ${file}`)
     const savePath = savePathFor(file, config)
     const draft = config.build.contents.draft || false
-    const html = jsToHtmlWith(file, elmcode, appjs, draft, autoReloader, config.build.contents.exclude || [])
+    const html = jsToHtmlWith(file, config.build.contents.src_dir, elmcode, appjs, draft, autoReloader, config.build.contents.exclude || [])
     if(html !== '') {
         // console.log(`< ${savePath}`)
         fs.ensureFileSync(savePath)

--- a/src/generator/jstohtml.ts
+++ b/src/generator/jstohtml.ts
@@ -33,11 +33,11 @@ class InvalidPreambleError extends ConvertError { name = 'Preamble' }
  * @param excludes which are excluded by indexing
  * @returns void
  */
-const jsToHtmlWith = (sourcePath: string, elmcode: string, appjsPath: string, withDraft: boolean, autoReloader: boolean, excludes: string[]): string => {
+const jsToHtmlWith = (sourcePath: string, srcDir: string, elmcode: string, appjsPath: string, withDraft: boolean, autoReloader: boolean, excludes: string[]): string => {
     try {
         // create flags
         const document = parseDocument(fs.readFileSync(sourcePath, 'utf-8'))
-        const p = parsePreamble(document[0], sourcePath, sourcePath, excludes)
+        const p = parsePreamble(document[0], sourcePath, `${srcDir}/*`, excludes)
         const flags = {
             preamble: JSON.stringify(p),
             body: document[1]


### PR DESCRIPTION
## Reproduce the problem

Here's the patch to show preamble.url on `articles/*` of the official blog template.

```diff
diff --git a/res/scaffold/blog/src/Static/Article.elm b/res/scaffold/blog/src/Static/Article.elm
index 752e476..7cc5c69 100644
--- a/res/scaffold/blog/src/Static/Article.elm
+++ b/res/scaffold/blog/src/Static/Article.elm
@@ -25,6 +25,7 @@ main =
 type alias Preamble =
     { title : String
     , date : Posix
+    , url : String
     }


@@ -33,6 +34,7 @@ preambleDecoder =
     Decode.succeed Preamble
         |> required "title" string
         |> required "date" Iso8601.decoder
+        |> required "url" string


 body : Preamble -> String -> List (Html Never)
@@ -60,6 +62,8 @@ body preamble markdown =
                 , Font.center
                 ]
                 [ text preamble.title
+                , text " - url: "
+                , text preamble.url
                 ]
             , el
                 [ Font.size 14
```

![image](https://user-images.githubusercontent.com/85887/82747465-d92eff80-9d4d-11ea-847e-4c656b5c6209.png)

`/articles` is missed from the actual URL string 😞